### PR TITLE
AlphaDroid: Battery Styles: Added 9 more battery styles [2/2]

### DIFF
--- a/res/values/cr_arrays.xml
+++ b/res/values/cr_arrays.xml
@@ -191,6 +191,15 @@
         <item>@string/status_bar_battery_style_filled_circle</item>
         <item>@string/status_bar_battery_style_text</item>
         <item>@string/status_bar_battery_style_hidden</item>
+        <item>@string/status_bar_battery_style_icon_landscape_buddy</item>
+        <item>@string/status_bar_battery_style_icon_landscape_line</item>
+        <item>@string/status_bar_battery_style_icon_landscape_musku</item>
+        <item>@string/status_bar_battery_style_icon_landscape_pill</item>
+        <item>@string/status_bar_battery_style_icon_landscape_signal</item>
+        <item>@string/status_bar_battery_style_icon_rlandscape_style_a</item>
+        <item>@string/status_bar_battery_style_icon_landscape_style_a</item>
+        <item>@string/status_bar_battery_style_icon_rlandscape_style_b</item>
+        <item>@string/status_bar_battery_style_icon_landscape_style_b</item>
     </string-array>
 
     <string-array name="status_bar_battery_style_values" translatable="false">
@@ -202,6 +211,15 @@
         <item>3</item>
         <item>4</item>
         <item>5</item>
+        <item>8</item>
+        <item>9</item>
+        <item>10</item>
+        <item>11</item>
+        <item>12</item>
+        <item>13</item>
+        <item>14</item>
+        <item>15</item>
+        <item>16</item>
     </string-array>
 
     <string-array name="status_bar_battery_percent_entries">

--- a/res/values/cr_strings.xml
+++ b/res/values/cr_strings.xml
@@ -419,6 +419,15 @@
     <string name="status_bar_battery_style_filled_circle">Filled circle</string>
     <string name="status_bar_battery_style_text">Text</string>
     <string name="status_bar_battery_style_hidden">Hidden</string>
+    <string name="status_bar_battery_style_icon_landscape_buddy">Landscape Capsule</string>
+    <string name="status_bar_battery_style_icon_landscape_line">Landscape Lorn</string>
+    <string name="status_bar_battery_style_icon_landscape_musku">Portrait IOS</string>
+    <string name="status_bar_battery_style_icon_landscape_pill">Portrait Mx</string>
+    <string name="status_bar_battery_style_icon_landscape_signal">Landscape Airoo</string>
+    <string name="status_bar_battery_style_icon_rlandscape_style_a">Landscape R Style A</string>
+    <string name="status_bar_battery_style_icon_landscape_style_a">Landscape L Style A</string>
+    <string name="status_bar_battery_style_icon_rlandscape_style_b">Landscape R Style B</string>
+    <string name="status_bar_battery_style_icon_landscape_style_b">Landscape L Style B</string>
     <string name="status_bar_battery_percent_title">Battery percent</string>
     <string name="status_bar_battery_percent_hidden">Hidden</string>
     <string name="status_bar_battery_percent_text_inside">Inside the icon</string>


### PR DESCRIPTION
Thanks to Another substratum theme for many icons:- https://t.me/AnotherTheme Thanks to @Fakeriz for battery icon style A.
Thanks to @Ndikarizki for battery icon style B.

Signed-off-by: Hưng Phan <phandinhhungvp2001@gmail.com>
Signed-off-by: helliscloser <mrumais@gmail.com>